### PR TITLE
Remove Discord Token from config

### DIFF
--- a/config.js
+++ b/config.js
@@ -20,7 +20,7 @@ const config = {
   "support": [],
 
   // Your Bot's Token. Available on https://discordapp.com/developers/applications/me
-  "token": "NDA0ODIxMzAzNTc3ODA0ODAy.DUlKIA.W3MalWZygsiazoFhk94vdk_tlfc",
+  "token": "TOKEN HERE",
 
 
   // Default per-server settings. New guilds have these settings. 


### PR DESCRIPTION
This is to remove any discord bot tokens from your **public** config file.

I also suggest updating your token in the developer portal if you havent already